### PR TITLE
Fix: [TD-94] Add Name and Surname to Current User Response in users/current Endpoint

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :document_number
+  attributes :id, :email, :document_number, :first_name, :last_name
 end

--- a/script/pre-push.sh
+++ b/script/pre-push.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "\033[34mRunning Rubocop\033[0m"
-RUN_CHECK_CMD='bundle exec rubocop app spec -R --format simple'
+RUN_CHECK_CMD='bundle exec rubocop app spec --format simple'
 RUN_TESTS_OUTPUT=`${RUN_CHECK_CMD}`
 
 if [ $? -eq 1 ]


### PR DESCRIPTION
## Summary

Se agrega a la respuesta del servicio current_user  la informacion del usuario su nombre y apellido.

## Screenshots

#### South Utility
![image](https://github.com/GonzaloWD/Training-Rails-UGUITO-API-Bootstrap/assets/160155300/f58426e8-0717-43c0-8d11-20fda7244076)


#### North Utility
![image](https://github.com/GonzaloWD/Training-Rails-UGUITO-API-Bootstrap/assets/160155300/a64171f9-7b10-4a1f-89b1-195fadc7526f)

## Test Cases

Se debe tener iniciada sesión del usuario para visualizar la información de current user (ir a card: TD-258 para configurar la API)

## Checklist 

- [x] Verifiqué / Realicé los cambios requeridos en Active Admin, o alguna configuración adicional (en caso de corresponder) ⚙️
- [x] Verifiqué si mis cambios requieren actualizar la documentación técnica y la actualicé (en caso de corresponder). 📝
- [x] Revisé los archivos modificados antes de liberar el pull request para revisión. 👩🏻‍💻
- [x] Actualicé la card de JIRA considerando: **estado**, **horas incurridas**, **enfoque tomado como comentario de la card** y **requisitos de configuración asociados**✅
- [x] El título de mi PR sigue la convención requerida 👉 [%scope - %descripcion](https://www.conventionalcommits.org/en/v1.0.0/)

- [x] **Post Merge** 👉 Actualicé el status de la card en JIRA.

## JIRA Card

https://widergy.atlassian.net/browse/TD-94]
